### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,13 @@ var locationPicker = $('.location-picker').locationPicker({
 				init:{ 
 					current_location: true, // True by default, initializes location picker with current location 
 					address : 'Put init adddress here',
-					location : {latitude, longitude} // put initial location here
-					}
-			}
-			// callback method
-			locationChanged : function(data){
+					location : {lat: <latitude>, lng: <longitude>} // put initial location here
+					},
+				// callback method
+				locationChanged : function(data){
 
-				$('#output').text(JSON.stringify(data));
-			}
+					$('#output').text(JSON.stringify(data));
+				}
 			
 		});
 </script>


### PR DESCRIPTION
Fix all available options example syntax

All available options example had missing comma at the end of init and one extra curly brace end. 
Moreover, the init location was not clear enough to understand the proper usage.
Both of these issues are fixed in this commit